### PR TITLE
Adds global params section.

### DIFF
--- a/apiplayground/static/api_browser/css/screen.css
+++ b/apiplayground/static/api_browser/css/screen.css
@@ -92,6 +92,12 @@ section.resource {
                 display: none;
             }
 
+            section.resource ul li .global {
+                padding: 10px 0;
+                background-color: #fbfbfb;
+                border-bottom: 1px solid #e8e8e8;
+            }
+
             section.resource ul li .result {
                 display: none;
             }

--- a/apiplayground/static/api_browser/js/app.js
+++ b/apiplayground/static/api_browser/js/app.js
@@ -7,7 +7,12 @@ var APIBrowser = $.Class.extend({
 
     selectors: {
         input_fields: "input[type='text'], input[type='checkbox'], textarea, select",
+        copied_fields: "input[isacopy], textarea[isacopy], select[isacopy]",
 
+        // Global elements
+        global_form : "#global-form",
+        global_inputs: "#global-form input[type='text'], #global-form input[type='checkbox'], #global-form textarea, #global-form select",
+ 
         // API Resources
         endpoint_form : ".endpoint form",
         endpoint_anchor: ".endpoint a",
@@ -37,9 +42,15 @@ var APIBrowser = $.Class.extend({
 
     load_rest_form: function () {
         $(this.selectors.endpoint_form).restForm({
+            "presubmit": this.presubmit_form.bind(this),
             "submit": this.submit_form.bind(this),
             "complete": this.complete_ajax_request.bind(this)
         });
+    },
+
+    presubmit_form: function (form) {
+        // Copy global paramaters to submitted form.
+        $(this.selectors.global_inputs).not(':submit').clone().hide().attr('isacopy','y').appendTo(form);
     },
 
     submit_form: function (form, request_headers) {
@@ -48,6 +59,9 @@ var APIBrowser = $.Class.extend({
     },
 
     complete_ajax_request: function (form, xhr) {
+        // Clear copied elements (prevent duplicates)
+        $(this.selectors.copied_fields).remove();
+
         form.siblings(this.selectors.response_status).show().find(
             this.selectors.code).html(xhr.statusText + " (" + xhr.status + ")");
 

--- a/apiplayground/static/api_browser/js/app.js
+++ b/apiplayground/static/api_browser/js/app.js
@@ -10,8 +10,7 @@ var APIBrowser = $.Class.extend({
         copied_fields: "input[isacopy], textarea[isacopy], select[isacopy]",
 
         // Global elements
-        global_form : "#global-form",
-        global_inputs: "#global-form input[type='text'], #global-form input[type='checkbox'], #global-form textarea, #global-form select",
+        global_inputs : "#global-form input[type='text'], #global-form input[type='checkbox'], #global-form textarea, #global-form select",
  
         // API Resources
         endpoint_form : ".endpoint form",

--- a/apiplayground/static/api_browser/js/jquery.rest-form.js
+++ b/apiplayground/static/api_browser/js/jquery.rest-form.js
@@ -14,6 +14,7 @@
 
     $.fn.restForm = function (_options) {
         var options = $.extend({
+            "presubmit": function () {},
             "submit": function () {},
             "complete": function () {}
         }, _options);
@@ -32,6 +33,10 @@
         this.each(function () {
             $(this).submit(function () {
                 var form = $(this);
+
+                // firing presubmit event
+                options.presubmit.call(this, form);
+
                 var data = form.form2json();
                 var method = form.attr("method");
                 var url = form.attr("action");

--- a/apiplayground/templates/api_browser/base.html
+++ b/apiplayground/templates/api_browser/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>API Browser</title>
+    <title>{{ schema.title }}</title>
     <link rel="stylesheet" href="{{ STATIC_URL }}api_browser/css/h5bp.css">
     <link rel="stylesheet" href="{{ STATIC_URL }}api_browser/css/screen.css">
 </head>

--- a/apiplayground/templates/api_browser/index.html
+++ b/apiplayground/templates/api_browser/index.html
@@ -3,6 +3,25 @@
 
 {% block content %}
 {% load api_browser_tags %}
+
+{% get_global_forms schema as global_forms %}
+{% if global_forms.data_parameter_form.fields %}
+<section class="resource">
+    <ul>
+        <li>
+            <section class="global">
+                <form id="global-form">
+                    <fieldset>
+                        <legend>Global Parameters</legend>
+                        {{ global_forms.data_parameter_form.as_p }}
+                    </fieldset>
+                </form>
+            </section>
+        </li>
+    </ul>
+</section>
+{% endif %}
+
 {% for resource in schema.resources %}
     <section class="resource">
         <header>

--- a/apiplayground/templatetags/api_browser_tags.py
+++ b/apiplayground/templatetags/api_browser_tags.py
@@ -5,6 +5,15 @@ register = template.Library()
 
 
 @register.assignment_tag()
+def get_global_forms(schema):
+    data_parameter_form = build_data_form(schema.get("parameters", []))
+
+    return {
+        "data_parameter_form": data_parameter_form
+    }
+
+
+@register.assignment_tag()
 def get_endpoint_forms(endpoint):
     url_parameter_form = build_url_form(endpoint.get("url", ""))
     data_parameter_form = build_data_form(endpoint.get("parameters", []))


### PR DESCRIPTION
Ernables a global parameters section per the thread in:
https://github.com/Hipo/Django-API-Playground/issues/5 

A parameters block may be specified directly at the schema root which will result in a data form being displayed at the top of the page. These elements are then applied to all the API calls on the page.

Example:
    "parameters": [{
        "name": "apikey",
        "type": "string",
        "is_required": True,
        "description": "apikey"
    }, {
        "name": "format",
        "type": "select",
        "choices": [["json", "json"], ["jsonp", "jsonp"], ["xml", "xml"], ],
    }]

This can admittedly use some design help. 
